### PR TITLE
Adds iCal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ This is a Python (3.6+) library for finding URLs in documents and checking their
 Extracts URLs from the following types of documents:
 
 * Binary files (finds URLs within strings)
+* CSV files
 * HTML files
+* iCalendar/vCalendar files
+* PDF files
 * Text files (ASCII or UTF-8)
 * XML files
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+icalendar>=4.0.7
 idna>=2.10
 lxml>=4.5.2
 python-magic>=0.4.18

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.15.6',
+    version='0.16.0',
 
     description='Library to find URLs and check their validity.',
     long_description=long_description,

--- a/tests/files/test.ical
+++ b/tests/files/test.ical
@@ -1,0 +1,27 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//My calendar product//abc.de//
+BEGIN:VEVENT
+SUMMARY:Urlfinderlib iCalendar test
+DTSTART;VALUE=DATE-TIME:20210404T080000Z
+DTEND;VALUE=DATE-TIME:20210404T100000Z
+DTSTAMP;VALUE=DATE-TIME:20210404T001000Z
+UID:20210115T101010/27346262376@abc.de
+DESCRIPTION:Lorem ipsum dolor sit amet\, consectetur adipiscing elit. <htt
+ ps://thisisjustatest.com> Mauris efficitur dolor hendrerit velit fringilla
+ \, id auctor urna aliquet. Ut ac tortor vel lacus mattis condimentum. Sed
+ fringilla elementum turpis id maximus. <https://thisisjustatest2.com> Vest
+ ibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubil
+ ia curae\; Sed semper dictum interdum. Suspendisse et sodales tortor\, at
+ viverra quam. Nulla vitae dictum urna\, nec laoreet neque. Integer <https:
+ //thisisjustatest3.com> tristique metus nec purus interdum\, aliquam euism
+ od libero accumsan. Donec vulputate velit nec libero consectetur iaculis.
+ Pellentesque a scelerisque felis\, quis tristique dolor. Etiam egestas veh
+ icula lobortis. Nam congue eleifend tellus\, in ultricies mauris. Aliquam
+ erat volutpat. Duis interdum\, lectus at lobortis faucibus\, metus lacus f
+ ermentum quam\, sit amet porta purus ex sit amet dui. Curabitur maximus lo
+ rem sit amet neque dapibus sodales.
+LOCATION:https://thisisjustatest4.com
+PRIORITY:5
+END:VEVENT
+END:VCALENDAR

--- a/tests/finders/test_ical.py
+++ b/tests/finders/test_ical.py
@@ -1,0 +1,5 @@
+import urlfinderlib.finders as finders
+
+
+def test_create_text():
+    assert finders.IcalUrlFinder('test')

--- a/tests/test_urlfinderlib.py
+++ b/tests/test_urlfinderlib.py
@@ -54,6 +54,20 @@ def test_find_urls_html():
     assert urlfinderlib.find_urls(blob) == expected_urls
 
 
+def test_find_urls_ical():
+    with open(f'{files_dir}/test.ical', 'rb') as f:
+        blob = f.read()
+
+        expected_urls = {
+            'https://thisisjustatest.com',
+            'https://thisisjustatest2.com',
+            'https://thisisjustatest3.com',
+            'https://thisisjustatest4.com'
+        }
+
+        assert urlfinderlib.find_urls(blob) == expected_urls
+
+
 def test_find_urls_in_text_like_html():
     blob = b'''<meta http-equiv="refresh" content="0; URL=https://blah.com/one/two">'''
     assert urlfinderlib.find_urls(blob) == {'https://blah.com/one/two'}

--- a/urlfinderlib/finders/__init__.py
+++ b/urlfinderlib/finders/__init__.py
@@ -1,6 +1,7 @@
 from urlfinderlib.finders.csv import CsvUrlFinder
 from urlfinderlib.finders.data import DataUrlFinder
 from urlfinderlib.finders.html import HtmlUrlFinder, HtmlTreeUrlFinder
+from urlfinderlib.finders.ical import IcalUrlFinder
 from urlfinderlib.finders.pdf import PdfUrlFinder
 from urlfinderlib.finders.text import TextUrlFinder
 from urlfinderlib.finders.xml import XmlUrlFinder

--- a/urlfinderlib/finders/ical.py
+++ b/urlfinderlib/finders/ical.py
@@ -1,0 +1,30 @@
+from icalendar import Calendar
+from typing import Set, Union
+
+from .text import TextUrlFinder
+from urlfinderlib.url import URLList
+
+
+class IcalUrlFinder:
+    def __init__(self, blob: Union[bytes, str]):
+        if isinstance(blob, str):
+            blob = blob.encode('utf-8', errors='ignore')
+
+        self.blob = blob
+
+    def find_urls(self) -> Set[str]:
+        urls = URLList()
+
+        ical = Calendar.from_ical(self.blob)
+        for component in ical.walk():
+            if component.name == 'VEVENT':
+                description = component.get('description')
+                location = component.get('location')
+
+                if description:
+                    urls += TextUrlFinder(description).find_urls(strict=True)
+
+                if location:
+                    urls += TextUrlFinder(location).find_urls(strict=True)
+
+        return set(urls)

--- a/urlfinderlib/urlfinderlib.py
+++ b/urlfinderlib/urlfinderlib.py
@@ -29,6 +29,8 @@ def find_urls(blob: Union[bytes, str], base_url: str = '', mimetype: str = '') -
     elif 'html' in mimetype:
         blob = _unescape_ascii(blob)
         urls += finders.HtmlUrlFinder(blob, base_url=base_url).find_urls()
+    elif 'vcalendar' in mimetype:
+        urls += finders.IcalUrlFinder(blob).find_urls()
     elif 'xml' in mimetype:
         urls += finders.XmlUrlFinder(blob).find_urls()
     elif b'%PDF-' in blob[:1024]:


### PR DESCRIPTION
iCal files have their lines wrapped, which cuts URLs off at the end of a line so that they can wrap to the next line. Without properly accounting for this, urlfinderlib would incorrectly extract these truncated URLs.