### PR TITLE
Finds URLs in the "onclick" tag attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.16.0',
+    version='0.16.1',
 
     description='Library to find URLs and check their validity.',
     long_description=long_description,

--- a/tests/files/test.html
+++ b/tests/files/test.html
@@ -41,5 +41,7 @@
         <a href="http://domain4.com/index.php#thing\x3dhttp://domain5.com">asdf</a>
 
         <div id="id"></div>
+
+        <button class="btn" onclick="window.location.href='https://domain6.com'">View File</button>
     </body>
 </html>

--- a/tests/test_urlfinderlib.py
+++ b/tests/test_urlfinderlib.py
@@ -48,7 +48,8 @@ def test_find_urls_html():
         'http://domain2.com/image-medium.png',
         'http://domain2.com/image-large.png',
         'http://domain4.com/index.php#thing=http://domain5.com',
-        'http://domain5.com'
+        'http://domain5.com',
+        'https://domain6.com',
     }
 
     assert urlfinderlib.find_urls(blob) == expected_urls

--- a/urlfinderlib/finders/html.py
+++ b/urlfinderlib/finders/html.py
@@ -251,6 +251,11 @@ class HtmlTreeUrlFinder:
             values |= {v for v in element.attrib.values()}
 
             for attrib in element.attrib:
+                # Ignore the "onclick" attribute since that contains JavaScript. By not replacing this value, it lets
+                # the TextUrlFinder attempt to extract URLs from it instead since it is not parsed by lxml.
+                if attrib.lower() == 'onclick':
+                    continue
+
                 element.attrib[attrib] = ''
 
         return values


### PR DESCRIPTION
The "onclick" tag attribute contains JavaScript and therefore is not parsed by lxml. The solution to this is to allow the TextUrlFinder to make a best effort at finding URLs inside of this attribute instead.