### PR TITLE
Fixes some incorrect URLs being extracted from email text bodies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.17.2',
+    version='0.17.3',
 
     description='Library to find URLs and check their validity.',
     long_description=long_description,

--- a/tests/finders/test_functional_text.py
+++ b/tests/finders/test_functional_text.py
@@ -11,6 +11,7 @@ text = b'''
 'http://domain.com/single_quotes'
  http://domain.com/spaces 
 http://domain.com/lines
+http://domain.com/text<http://domain.com/actual>
 '''
 
 
@@ -26,7 +27,9 @@ def test_find_urls_in_text():
         'http://domain.com/parentheses',
         'http://domain.com/single_quotes',
         'http://domain.com/spaces',
-        'http://domain.com/lines'
+        'http://domain.com/lines',
+        'http://domain.com/text',
+        'http://domain.com/actual',
     }
 
     assert finder.find_urls() == expected_urls

--- a/urlfinderlib/finders/text.py
+++ b/urlfinderlib/finders/text.py
@@ -35,6 +35,14 @@ class TextUrlFinder:
 
         valid_urls = URLList()
         for token in tokens:
+            # It is common for text files like email plaintext bodies to encode URLs in the form of:
+            # http://domain.com<http://actualdomain.com>
+            # where the text at the beginning is what will be displayed, and the text inside the <> is the
+            # actual URL you will be taken to if you click on it. In these cases, we don't want that entire string
+            # to be considered as a valid URL, but would rather have each of them as separate URLs.
+            if '<' in token and token.endswith('>'):
+                continue
+
             valid_urls.append(helpers.fix_possible_url(token))
 
         return set(valid_urls)


### PR DESCRIPTION
It is common for email plaintext bodies to encode URLs like:

```
http://domain.com/display<http://domain.com/actual>
```

Where the text at the beginning is what will be displayed when the email body is displayed, and the URL inside of the <> is the actual URL you will be directed to if you click on it. In these cases, we want to extract each URL separately but do not want to consider the entire thing as a valid URL.