### PR TITLE
Fixes IDNA netloc issue and adds idna_percent_encoded property

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.17.6',
+    version='0.17.7',
 
     description='Library to find URLs and check their validity.',
     long_description=long_description,

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -131,6 +131,10 @@ def test_get_scheme():
     assert URL('http://dom[ain.com').split_value.scheme == ''
 
 
+def test_idna_percent_encoded():
+    assert URL('http://উদাহরণ.বাংলা:8080/about us/index.html').idna_percent_encoded == 'http://xn--d5b6ci4b4b3a.xn--54b7fta0cc:8080/about%20us/index.html'
+
+
 def test_is_netloc_ipv4():
     valid_ipv4_netloc = [
         'http://1.1.1.1',

--- a/urlfinderlib/url.py
+++ b/urlfinderlib/url.py
@@ -140,6 +140,12 @@ class URL:
         return self._fragment_dict
 
     @property
+    def idna_percent_encoded(self) -> str:
+        """Returns the URL with the IDNA version of the domain and the percent encoded path"""
+        
+        return f'{self.split_value.scheme}://{self.netloc_idna}{self.path_percent_encoded}' 
+
+    @property
     def is_mandrillapp(self) -> bool:
         if self._is_mandrillapp is None:
             self._is_mandrillapp = 'mandrillapp.com' in self.value_lower and 'p' in self.query_dict
@@ -236,11 +242,13 @@ class URL:
                 return self._netloc_idna
 
             try:
-                self._netloc_idna = idna.encode(self.split_value.netloc).decode('utf-8').lower()
+                idna_hostname = idna.encode(self.split_value.hostname).decode('utf-8').lower()
+                self._netloc_idna = self.split_value.netloc.replace(self.split_value.hostname, idna_hostname)
                 return self._netloc_idna
             except idna.core.IDNAError:
                 try:
-                    self._netloc_idna = self.split_value.netloc.encode('idna').decode('utf-8', errors='ignore').lower()
+                    idna_hostname = self.split_value.hostname.encode('idna').decode('utf-8', errors='ignore').lower()
+                    self._netloc_idna = self.split_value.netloc.replace(self.split_value.hostname, idna_hostname)
                     return self._netloc_idna
                 except UnicodeError:
                     self._netloc_idna = ''


### PR DESCRIPTION
This adds the `idna_percent_encoded` property to get a "safe" version of the URL. In adding this, I discovered that there was a bug with how the IDNA netlocs were being created if there was a port in the URL. This fixes that issue as well.