### PR TITLE
Fixes issue with mandrillapp and proofpoint URL identification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.17.7',
+    version='0.17.8',
 
     description='Library to find URLs and check their validity.',
     long_description=long_description,

--- a/urlfinderlib/url.py
+++ b/urlfinderlib/url.py
@@ -148,7 +148,7 @@ class URL:
     @property
     def is_mandrillapp(self) -> bool:
         if self._is_mandrillapp is None:
-            self._is_mandrillapp = 'mandrillapp.com' in self.value_lower and 'p' in self.query_dict
+            self._is_mandrillapp = 'mandrillapp.com' in self.split_value.hostname and 'p' in self.query_dict
 
         return self._is_mandrillapp
 
@@ -191,7 +191,7 @@ class URL:
     @property
     def is_proofpoint_v2(self) -> bool:
         if self._is_proofpoint_v2 is None:
-            self._is_proofpoint_v2 = (
+            self._is_proofpoint_v2 = 'urldefense' in self.split_value.hostname and (
                 'urldefense.proofpoint.com/v2' in self.value_lower or 'urldefense.com/v2' in self.value_lower
             ) and 'u' in self.query_dict
 
@@ -200,8 +200,8 @@ class URL:
     @property
     def is_proofpoint_v3(self) -> bool:
         if self._is_proofpoint_v3 is None:
-            self._is_proofpoint_v3 = 'urldefense.proofpoint.com/v3' in self.value_lower or \
-                                     'urldefense.com/v3' in self.value_lower
+            self._is_proofpoint_v3 = 'urldefense' in self.split_value.hostname and (
+                'urldefense.proofpoint.com/v3' in self.value_lower or 'urldefense.com/v3' in self.value_lower)
 
         return self._is_proofpoint_v3
 


### PR DESCRIPTION
There was a bug with how mandrillapp (and also proofpoint) URLs were being identified when they were double encoded - as in a mandrillapp URL inside of a proofpoint URL. Prior to this fix, it did a very simple check to identify mandrillapp and would throw an error since it would try and handle the "parent" proofpoint URL as a mandrillapp one instead.

This fixes #55